### PR TITLE
option and result are added to docs and tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orx-iterable"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "Defines and implements Iterable, Collection and CollectionMut traits to represent types that can be iterated over multiple times."

--- a/README.md
+++ b/README.md
@@ -70,11 +70,14 @@ fn statistics(numbers: &impl Collection<Item = i64>) -> Stats {
 
 statistics(&[3, 5, 7]);
 statistics(&vec![3, 5, 7]);
-statistics(&LinkedList::from_iter([3, 5, 7]));
-statistics(&VecDeque::from_iter([3, 5, 7]));
-statistics(&HashSet::<_>::from_iter([3, 5, 7]));
-statistics(&BTreeSet::<_>::from_iter([3, 5, 7]));
-statistics(&BinaryHeap::<_>::from_iter([3, 5, 7]));
+statistics(&LinkedList::from([3, 5, 7]));
+statistics(&VecDeque::from([3, 5, 7]));
+statistics(&HashSet::<_>::from([3, 5, 7]));
+statistics(&BTreeSet::<_>::from([3, 5, 7]));
+statistics(&BinaryHeap::<_>::from([3, 5, 7]));
+
+statistics(&Some(11));
+statistics(&Ok::<_, &str>(11));
 
 let x: SmallVec<[_; 128]> = smallvec![3, 5, 7];
 statistics(&x);
@@ -116,10 +119,16 @@ assert_eq!(x, [7, 8, 9]);
 let mut x = vec![1, 2, 3];
 increment_by_sum(&mut x);
 
-let mut x = LinkedList::from_iter([1, 2, 3]);
+let mut x = LinkedList::from([1, 2, 3]);
 increment_by_sum(&mut x);
 
-let mut x = VecDeque::from_iter([1, 2, 3]);
+let mut x = VecDeque::from([1, 2, 3]);
+increment_by_sum(&mut x);
+
+let mut x = Some(7);
+increment_by_sum(&mut x);
+
+let mut x: Result<_, &str> = Ok(7);
 increment_by_sum(&mut x);
 
 let mut x: SmallVec<[_; 128]> = smallvec![3, 5, 7];
@@ -186,19 +195,25 @@ statistics(x.copied()); // see section C for details of copied()
 let x = vec![3, 5, 7];
 statistics(x.copied());
 
-let x = LinkedList::from_iter([3, 5, 7]);
+let x = LinkedList::from([3, 5, 7]);
 statistics(x.copied());
 
-let x = VecDeque::from_iter([3, 5, 7]);
+let x = VecDeque::from([3, 5, 7]);
 statistics(x.copied());
 
-let x = HashSet::<_>::from_iter([3, 5, 7]);
+let x = HashSet::<_>::from([3, 5, 7]);
 statistics(x.copied());
 
-let x = BTreeSet::from_iter([3, 5, 7]);
+let x = BTreeSet::from([3, 5, 7]);
 statistics(x.copied());
 
-let x = BinaryHeap::from_iter([3, 5, 7]);
+let x = BinaryHeap::from([3, 5, 7]);
+statistics(x.copied());
+
+let x = Some(7);
+statistics(x.copied());
+
+let x: Result<_, &str> = Ok(7);
 statistics(x.copied());
 
 let x: SmallVec<[_; 128]> = smallvec![3, 5, 7];

--- a/tests/collection.rs
+++ b/tests/collection.rs
@@ -11,6 +11,12 @@ fn std_collections() {
     test_col(values(), vec![1, 3, 7]);
     test_col(values(), VecDeque::from_iter([1, 3, 7].into_iter()));
     test_col(values(), LinkedList::from_iter([1, 3, 7].into_iter()));
+
+    test_col(vec![10], Some(10));
+    test_col(vec![], None);
+
+    test_col(vec![10], Result::<_, String>::Ok(10));
+    test_col(vec![], Result::<_, String>::Err("error".to_string()));
 }
 
 #[test]
@@ -43,4 +49,10 @@ fn obj_custom_collection() {
     };
 
     obj_test_col(vec![4, 12, 8, 2, 1, 7], &col);
+
+    obj_test_col(vec![10], &Some(10));
+    obj_test_col(vec![], &None);
+
+    obj_test_col(vec![10], &Result::<_, String>::Ok(10));
+    obj_test_col(vec![], &Result::<_, String>::Err("error".to_string()));
 }

--- a/tests/iterable.rs
+++ b/tests/iterable.rs
@@ -13,6 +13,12 @@ fn std_collections() {
     test_it(values(), &LinkedList::from_iter([1, 3, 7].into_iter()));
     test_it(values(), &HashSet::<_>::from_iter([1, 3, 7].into_iter()));
     test_it(values(), &BTreeSet::<_>::from_iter([1, 3, 7].into_iter()));
+
+    test_it(vec![10], &Some(10));
+    test_it(vec![], &None);
+
+    test_it(vec![10], &Result::<_, String>::Ok(10));
+    test_it(vec![], &Result::<_, String>::Err("error".to_string()));
 }
 
 #[test]
@@ -49,6 +55,12 @@ fn obj_std_collections() {
     obj_test_it(values(), &&LinkedList::from_iter([1, 3, 7].into_iter()));
     obj_test_it(values(), &&HashSet::<_>::from_iter([1, 3, 7].into_iter()));
     obj_test_it(values(), &&BTreeSet::<_>::from_iter([1, 3, 7].into_iter()));
+
+    obj_test_it(vec![10], &&Some(10));
+    obj_test_it(vec![], &&None);
+
+    obj_test_it(vec![10], &&Result::<_, String>::Ok(10));
+    obj_test_it(vec![], &&Result::<_, String>::Err("error".to_string()));
 }
 
 #[test]


### PR DESCRIPTION
`Option` and `Result` types as well satisfy Iterable, Collection and CollectionMut requirements; and hence, implicitly implement these traits. These two type constructors are added to the examples in documentation and included in the tests.