### PR TITLE
Migrate to 2024edition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain: ["stable"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install toolchain
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+
+    - name: Install 32bit target
+      run: rustup target add i686-unknown-linux-musl
+    - name: Install wasm target
+      run: rustup target add wasm32v1-none
+    - name: Install miri
+      run: rustup component add --toolchain nightly-x86_64-unknown-linux-gnu miri
+    - name: Install no-std-check
+      run: cargo install cargo-no-std-check
+      
+    - name: Build
+      run: cargo build --verbose
+    - name: Build-32bit
+      run: cargo build --verbose --target i686-unknown-linux-musl
+    - name: Build-wasm
+      run: cargo build --verbose --no-default-features --target wasm32v1-none
+
+    - name: Test
+      run: cargo test --verbose
+    - name: Test-32bit
+      run: cargo test --verbose --target i686-unknown-linux-musl
+    - name: Check-wasm
+      run: cargo check --verbose --no-default-features --target wasm32v1-none
+
+    - name: Clippy
+      run: cargo clippy -- -D warnings --verbose
+
+    - name: Miri
+      run: cargo +nightly miri test --verbose
+
+    - name: NoStd
+      run: cargo +nightly no-std-check --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "orx-iterable"
-version = "1.2.0"
-edition = "2021"
+version = "1.3.0"
+edition = "2024"
 authors = ["orxfun <orx.ugur.arikan@gmail.com>"]
 description = "Defines and implements Iterable, Collection and CollectionMut traits to represent types that can be iterated over multiple times."
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ keywords = ["iterable", "collection", "iterator", "intoiterator", "enumerable"]
 categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-self-or = "1.1.1"
+orx-self-or = { path = "../orx-self-or" }
 
 [dev-dependencies]
 arrayvec = { version = "0.7.6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,11 @@ keywords = ["iterable", "collection", "iterator", "intoiterator", "enumerable"]
 categories = ["data-structures", "rust-patterns", "no-std"]
 
 [dependencies]
-orx-self-or = { path = "../orx-self-or" }
+orx-self-or = "1.2.0"
 
 [dev-dependencies]
 arrayvec = { version = "0.7.6", default-features = false }
-smallvec = { version = "1.13.2", default-features = false }
+smallvec = { version = "1.15.0", default-features = false }
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Not all iterables are collections storing elements. For instance, a *Range* is i
 
 In addition, **object safe variants** of these traits, `IterableObj`, `CollectionObj` and `CollectionMutObj` are provided, please see section E for details.
 
+> **no-std**: This crate supports **no-std**; however, *std* is added as a default feature. Please include with **no-default-features** for no-std use cases: `cargo add orx-iterable --no-default-features`.
+
 ## A. Collection and CollectionMut
 
 The core method of the Collection trait is `iter(&self)` which returns an iterator yielding shared references; i.e., `&Item`.


### PR DESCRIPTION
Migrated to 2024edition.

CI action is added.

Documentation is updated for no-std.
